### PR TITLE
helm: update chart version

### DIFF
--- a/charts/corp-gh-org-controller/values.yaml
+++ b/charts/corp-gh-org-controller/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/weaveworks/corp-gh-org-controller
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: "v1.0.0-rc.1"
 
 # required configuration
 billingEmail: ""


### PR DESCRIPTION
Set controller chart image version to v1.0.0-rc.1

Signed-off-by: Piaras Hoban <phoban01@gmail.com>